### PR TITLE
update to latest spectator-go with monotonic counter fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Library to collect runtime metrics for Golang applications using [spectator-go](https://github.com/Netflix/spectator-go).
 
+Requires `spectatord >= 0.11.1`, due to the use of `MonotonicCounterUint`.
+
 ## Instrumenting Code
 
 ```go

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Netflix/spectator-go-runtime-metrics
 
 go 1.21
 
-require github.com/Netflix/spectator-go/v2 v2.0.2
+require github.com/Netflix/spectator-go/v2 v2.0.3

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/Netflix/spectator-go/v2 v2.0.2 h1:KOWGXeewFYZeQ+GBob4gwlUe5LJOlP2VYedSGBwzK9U=
-github.com/Netflix/spectator-go/v2 v2.0.2/go.mod h1:aWA4AXO8aiq+x3cTafN4lGYv9ayx864IZoYyGo78K8Y=
+github.com/Netflix/spectator-go/v2 v2.0.3 h1:sB+hngNTtBSj3nvTNZaruUvnCjo/YDTjihzmekfZ44Q=
+github.com/Netflix/spectator-go/v2 v2.0.3/go.mod h1:aWA4AXO8aiq+x3cTafN4lGYv9ayx864IZoYyGo78K8Y=

--- a/runtime-metrics/memstats.go
+++ b/runtime-metrics/memstats.go
@@ -12,11 +12,11 @@ type memStatsCollector struct {
 	clock            Clock
 	registry         spectator.Registry
 	bytesAlloc       *meter.Gauge
-	allocationRate   *meter.MonotonicCounter
+	allocationRate   *meter.MonotonicCounterUint
 	totalBytesSystem *meter.Gauge
 	numLiveObjects   *meter.Gauge
-	objectsAllocated *meter.MonotonicCounter
-	objectsFreed     *meter.MonotonicCounter
+	objectsAllocated *meter.MonotonicCounterUint
+	objectsFreed     *meter.MonotonicCounterUint
 
 	gcLastPauseTimeValue uint64
 	gcPauseTime          *meter.Timer
@@ -49,8 +49,8 @@ func updateMemStats(m *memStatsCollector, mem *runtime.MemStats) {
 	secondsSinceLastGC := float64(timeSinceLastGC) / 1e9
 	m.gcAge.Set(secondsSinceLastGC)
 
-	m.gcCount.Set(uint64(mem.NumGC))
-	m.forcedGcCount.Set(uint64(mem.NumForcedGC))
+	m.gcCount.Set(float64(mem.NumGC))
+	m.forcedGcCount.Set(float64(mem.NumForcedGC))
 	m.gcPercCpu.Set(mem.GCCPUFraction * 100)
 }
 
@@ -58,11 +58,11 @@ func initializeMemStatsCollector(registry spectator.Registry, clock Clock, mem *
 	mem.clock = clock
 	mem.registry = registry
 	mem.bytesAlloc = registry.Gauge("mem.heapBytesAllocated", nil)
-	mem.allocationRate = registry.MonotonicCounter("mem.allocationRate", nil)
+	mem.allocationRate = registry.MonotonicCounterUint("mem.allocationRate", nil)
 	mem.totalBytesSystem = registry.Gauge("mem.maxHeapBytes", nil)
 	mem.numLiveObjects = registry.Gauge("mem.numLiveObjects", nil)
-	mem.objectsAllocated = registry.MonotonicCounter("mem.objectsAllocated", nil)
-	mem.objectsFreed = registry.MonotonicCounter("mem.objectsFreed", nil)
+	mem.objectsAllocated = registry.MonotonicCounterUint("mem.objectsAllocated", nil)
+	mem.objectsFreed = registry.MonotonicCounterUint("mem.objectsFreed", nil)
 	mem.gcPauseTime = registry.Timer("gc.pauseTime", nil)
 	mem.gcAge = registry.Gauge("gc.timeSinceLastGC", nil)
 	mem.gcCount = registry.MonotonicCounter("gc.count", nil)


### PR DESCRIPTION
There are now two main `MonotonicCounter` types - one for `float64` and one for `uint64`. The float version should be used when there is a need to transform source data values into base units, while the uint version can be used for data values that are already in base units.