### PR TITLE
switch uses of MonotonicCounterUint to MonotonicCounter as a stop-gap

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 Library to collect runtime metrics for Golang applications using [spectator-go](https://github.com/Netflix/spectator-go).
 
-Requires `spectatord >= 0.11.1`, due to the use of `MonotonicCounterUint`.
-
 ## Instrumenting Code
 
 ```go


### PR DESCRIPTION
The required spectatord version >= 0.11.1 is not widely adopted in the environment just yet, and we want to be able to pick up this library in nflx-otel-collector, which will see wide usage across the fleet.