### PR TITLE
change package name to fit Go style recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Library to collect runtime metrics for Golang applications using [spectator-go](
 package main
 
 import (
-	"github.com/Netflix/spectator-go-runtime-metrics/runtime-metrics"
+	"github.com/Netflix/spectator-go-runtime-metrics/runmetrics"
 	"github.com/Netflix/spectator-go/v2/spectator"
 )
 
@@ -21,6 +21,6 @@ func main() {
 	registry, _ := spectator.NewRegistry(config)
 	defer registry.Close()
 
-	runtime_metrics.CollectRuntimeMetrics(registry)
+	runmetrics.CollectRuntimeMetrics(registry)
 }
 ```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/Netflix/spectator-go-runtime-metrics
 
 go 1.21
 
-require github.com/Netflix/spectator-go/v2 v2.0.3
+require github.com/Netflix/spectator-go/v2 v2.0.4

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/Netflix/spectator-go/v2 v2.0.3 h1:sB+hngNTtBSj3nvTNZaruUvnCjo/YDTjihzmekfZ44Q=
-github.com/Netflix/spectator-go/v2 v2.0.3/go.mod h1:aWA4AXO8aiq+x3cTafN4lGYv9ayx864IZoYyGo78K8Y=
+github.com/Netflix/spectator-go/v2 v2.0.4 h1:PmKiy+/K1OFJh0rHju6XeL8J0/5wjbQDccs/YtqXXtw=
+github.com/Netflix/spectator-go/v2 v2.0.4/go.mod h1:aWA4AXO8aiq+x3cTafN4lGYv9ayx864IZoYyGo78K8Y=

--- a/runmetrics/clock.go
+++ b/runmetrics/clock.go
@@ -1,4 +1,4 @@
-package runtime_metrics
+package runmetrics
 
 import (
 	"sync/atomic"

--- a/runmetrics/fd_linux.go
+++ b/runmetrics/fd_linux.go
@@ -1,4 +1,4 @@
-package runtime_metrics
+package runmetrics
 
 import (
 	"os"

--- a/runmetrics/fd_noop.go
+++ b/runmetrics/fd_noop.go
@@ -1,7 +1,7 @@
 //go:build !linux
 // +build !linux
 
-package runtime_metrics
+package runmetrics
 
 func fdStats(s *sysStatsCollector) {
 	// do nothing

--- a/runmetrics/memstats.go
+++ b/runmetrics/memstats.go
@@ -1,4 +1,4 @@
-package runtime_metrics
+package runmetrics
 
 import (
 	"runtime"

--- a/runmetrics/memstats_test.go
+++ b/runmetrics/memstats_test.go
@@ -1,4 +1,4 @@
-package runtime_metrics
+package runmetrics
 
 import (
 	"runtime"

--- a/runmetrics/runtime.go
+++ b/runmetrics/runtime.go
@@ -1,4 +1,4 @@
-package runtime_metrics
+package runmetrics
 
 import (
 	"runtime"


### PR DESCRIPTION
https://go.dev/blog/package-names
    
Also, update to the latest spectator-go.